### PR TITLE
fix: point sites resource download URL to live datastore dump

### DIFF
--- a/sites-workflow/datapump.py
+++ b/sites-workflow/datapump.py
@@ -249,15 +249,17 @@ def append_to_datastore(resource_id, df):
 
 
 def update_resource_metadata(resource_id):
-    """Update resource description with timestamp"""
+    """Update resource description and point download URL to live datastore dump"""
 
     timestamp = datetime.utcnow().isoformat() + 'Z'
+    dump_url = f"{CKAN_URL}/datastore/dump/{resource_id}?bom=True&format=csv"
 
     resource_patch_url = f"{CKAN_URL}/api/3/action/resource_patch"
     headers = {'Authorization': API_KEY}
 
     data = {
         'id': resource_id,
+        'url': dump_url,
         'description': f'Dynamic metadata for CKAN sites - time series data. Last updated: {timestamp}'
     }
 
@@ -271,7 +273,8 @@ def update_resource_metadata(resource_id):
         if response.status_code == 200:
             result = response.json()
             if result.get('success'):
-                print("✓ Resource metadata updated")
+                print("✓ Resource metadata and download URL updated")
+                print(f"  Download URL now points to: {dump_url}")
                 return True
     except Exception as e:
         logger.error(f"Error updating metadata: {e}")


### PR DESCRIPTION
After each successful datastore_upsert, patch the resource url to CKAN's datastore_dump endpoint so the Download button always serves live data instead of the frozen original file upload.


  - Fixes the mismatch between the resource's Download button (frozen CSV,                                                                                                                                                                                                                                             
    rows, max timestamp 2026-04-12)                                     
  - In `update_resource_metadata`, patches the resource `url` to CKAN's                                                                                                                                                                                                                                                
    `datastore_dump` endpoint after every successful upsert — no re-upload needed                                                                                                                                                                                                                                      
  - Both the Download button and the table toolbar's Download CSV now serve      
    the same live data                                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                       
  ## Root cause
                                                                                                                                                                                                                                                                                                                       
  `datapump.py` appended rows via `datastore_upsert` but never updated the                                                                                                                                                                                                                                           
  resource file or its URL. CKAN treats the file attachment and the datastore
  as separate things, so the Download button kept serving the original static upload.
                                                                                                                                                                                                                                                                                                                       
  ## Fix
                                                                                                                                                                                                                                                                                                                       
  Added `url` field to the existing `resource_patch` call in `update_resource_metadata`:                                                                                                                                                                                                                             
                                                                                        
      dump_url = f"{CKAN_URL}/datastore/dump/{resource_id}?bom=True&format=csv"
      data = {                                                                                                                                                                                                                                                                                                         
          'id': resource_id,
          'url': dump_url,                                                                                                                                                                                                                                                                                             
          'description': f'Dynamic metadata for CKAN sites - time series data. Last updated: {timestamp}'                                                                                                                                                                                                            
      }                                                                                                  
                                                                                                                                                                                                                                                                                                                       
  ## Test plan
                                                                                                                                                                                                                                                                                                                       
  - [ ] Run `datapump.py` with a valid `CKAN_API_KEY` and confirm output shows the dump URL                                                                                                                                                                                                                          
  - [ ] Verify the Download button URL on the resource page points to `/datastore/dump/<resource_id>?bom=True&format=csv`                                                                                                                                                                                              
  - [ ] Confirm downloaded file row count matches the live datastore total